### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Setup
 -----
-FuzzySully is a Python package. It requires at least Python 3.10. 
+FuzzySully is a Python package. It requires at least Python 3.11. 
 
 1. Create a virtual environment: `python3 -m venv fuzzysully-venv`
 2. Activate your virtual environment: `. ./fuzzysully-venv/bin/activate`


### PR DESCRIPTION
Python 3.11 is required; running with Python 3.10 results in an error like this:

```
    from enum import StrEnum
ImportError: cannot import name 'StrEnum' from 'enum' 
```